### PR TITLE
Double Submit on Checkout Bug fix

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,5 +1,7 @@
 jQuery(document).ajaxComplete(function(event,response,xhr){
     jQuery('.threeds_loading').hide();
+    $('#place_order').prop('disabled', false);
+
   try {
       jQuery('#paycertify_3ds_iframe').remove();
     jQuery.parseJSON( response.responseText );
@@ -9,6 +11,7 @@ jQuery(document).ajaxComplete(function(event,response,xhr){
     jQuery('.woocommerce-error').remove();
     jQuery('div.payment_method_paycertify').append(div);
 
+    $('#place_order').prop('disabled', true);
     jQuery('.threeds_loading').show();
   }
 });


### PR DESCRIPTION
Prevents the double-clicking of the submit button on checkout while the 3DS callback is running. This causes customers to be charged twice for the same invoice.

This appears to be an issue on IE10 and iOS Safari and not an issue on Google Chrome.

I haven't tested any other browsers. There may be a better way to implement this on the PHP side of things.

Signed-off-by: Rico Callirgos <rico.callirgos@praxent.com>